### PR TITLE
allow for extension packaging with nw.js

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -127,7 +127,7 @@ RoonApi.prototype.init_services = function(o) {
 //      Node:       require('fs')
 //      WebBrowser: localStroage
 //
-if (typeof(window) == "undefined") {
+if (typeof(window) == "undefined" || typeof(nw) !== "undefined") {
     RoonApi.prototype.start_discovery = function() {
 	if (this._sood) return;
 	this._sood = require('./sood.js');


### PR DESCRIPTION
extensions packaged with nw.js do have a window object, so add a check for the nw object as well to allow discovery. otoh, maybe a more elegant solution than this quick hack is needed to allow for additional packagers/distribution methods.