### PR TITLE
call core_paired/core_unpaired when pairing changed, not just lost/found

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -128,8 +128,15 @@ RoonApi.prototype.init_services = function(o) {
 		    req.send_complete("Success", { paired_core_id: this.paired_core_id });
 		},
 		pair: (req) => {
-		    this.paired_core_id = req.moo.core.core_id;
-		    svc.send_continue_all("subscribe_pairing", "Changed", { paired_core_id: this.paired_core_id  })
+                    if (!this.paired_core_id || (this.paired_core_id != req.moo.core.core_id)) {
+		        if (this.paired_core) {
+                            this.pairing_service_1.lost_core(this.paired_core);
+                            delete this.paired_core_id;
+                            delete this.paired_core;
+                        }
+                        this.pairing_service_1.found_core(req.moo.core);		      
+                    }
+                    svc.send_continue_all("subscribe_pairing", "Changed", { paired_core_id: this.paired_core_id  })
 		},
 	    }
 	});
@@ -144,6 +151,7 @@ RoonApi.prototype.init_services = function(o) {
 		    this.set_persisted_state(settings);
 
 		    this.paired_core_id = core.core_id;
+                    this.paired_core = core;
                     this.is_paired = true;
 		    svc.send_continue_all("subscribe_pairing", "Changed", { paired_core_id: this.paired_core_id  })
 		}

--- a/lib.js
+++ b/lib.js
@@ -128,15 +128,14 @@ RoonApi.prototype.init_services = function(o) {
 		    req.send_complete("Success", { paired_core_id: this.paired_core_id });
 		},
 		pair: (req) => {
-                    if (!this.paired_core_id || (this.paired_core_id != req.moo.core.core_id)) {
+                    if (this.paired_core_id != req.moo.core.core_id) {
 		        if (this.paired_core) {
                             this.pairing_service_1.lost_core(this.paired_core);
                             delete this.paired_core_id;
                             delete this.paired_core;
                         }
-                        this.pairing_service_1.found_core(req.moo.core);		      
+                        this.pairing_service_1.found_core(req.moo.core);
                     }
-                    svc.send_continue_all("subscribe_pairing", "Changed", { paired_core_id: this.paired_core_id  })
 		},
 	    }
 	});


### PR DESCRIPTION
This fixes the issue here:  https://community.roonlabs.com/t/pairing-core-functionality-issue/48964