### PR TITLE
treat incomplete moo messages from websocket transport as errors

### DIFF
--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -23,7 +23,9 @@ function Transport(ip, http_port, tcp_port, logger) {
     this.ws.onmessage = (event) => {
         if (!this.moo) return;
         var result = this.moo.parse(event.data);
-        if (!result || result.is_error) {
+        //the websocket transport promises that we will get one moo message
+        //per websocket message, so an incomplete message implies an error
+        if (!result || result.is_error || !result.is_complete) {
             this.close();
             return;
         }


### PR DESCRIPTION
This feels like the correct fix for https://github.com/RoonLabs/node-roon-api/issues/12 and https://community.roonlabs.com/t/js-extension-crash-after-suspend/49458/5

We could also consider a check for undefined in handle_response in moo.js, but I feel like that case is always going to be caused by a bug in our code rather than an expected error condition from the outside world.