### PR TITLE
Sood and onerror fixes

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -115,11 +115,22 @@ function RoonApi(o) {
             this._sood = require('./sood.js')(this.logger);
             this._sood_conns = {};
             this._sood.on('message', msg => {
-    //	    this.logger.log(msg);
+                //this.logger.log(msg);
                 if (msg.props.service_id == "00720724-5143-4a9b-abac-0e50cba674bb" && msg.props.unique_id) {
-                    if (this._sood_conns[msg.props.unique_id]) return;
-                    this._sood_conns[msg.props.unique_id] = true;
-                    this.ws_connect({ host: msg.from.ip, port: msg.props.http_port, onclose: () => { delete(this._sood_conns[msg.props.unique_id]); } });
+                    if (this._sood_conns[msg.props.unique_id]) {
+                        if (this._sood_conns[msg.props.unique_id].transport.host == msg.from.ip) {
+                            return;
+                        } else {
+                            this._sood_conns[msg.props.unique_id].transport.close();
+                        }
+                    }
+                    this._sood_conns[msg.props.unique_id] = this.ws_connect({
+                        host: msg.from.ip,
+                        port: msg.props.http_port,
+                        onclose: () => {
+                            delete(this._sood_conns[msg.props.unique_id]);
+                        }
+                    });
                 }
             });
             this._sood.on('network', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-roon-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Roon Api Library",
   "main": "lib.js",
   "author": "Roon Labs, LLC",

--- a/sood.js
+++ b/sood.js
@@ -55,6 +55,14 @@ function _parse(buf, minfo) {
 	    }
 	    msg.props[name] = val;
 	}
+        if (msg.props["_replyaddr"]) {
+            msg.from.ip = msg.props["_replyaddr"];
+            delete msg.props["_replyaddr"];
+        }
+        if (msg.props["_replyport"]) {
+            msg.from.port = msg.props["_replyport"];
+            delete msg.props["_replyport"];
+        }
 	return msg;
 
     } catch (e) {

--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -20,6 +20,10 @@ function Transport(ip, port, logger) {
         this.close();
     };
 
+    this.ws.onerror = (err) => {
+        this.onerror();
+    }
+
     this.ws.onmessage = (event) => {
         var msg = this.moo.parse(event.data);
         if (!msg) {
@@ -53,6 +57,7 @@ Transport.prototype.close = function() {
 
 Transport.prototype.onopen = function() { };
 Transport.prototype.onclose = function() { };
+Transport.prototype.onerror = function() { };
 Transport.prototype.onmessage = function() { };
 
 exports = module.exports = Transport;


### PR DESCRIPTION
This fixes two problems:
1. A library user found a situation in which not having an `onerror` handler for websocket connections caused a popup to appear to end users when there was a problem with the websocket connection
2. Previously we assumed that core ip addresses never changed, which is just false.  Fixing this also exposed a missing detail in our SOOD implementation, so this PR corrects that as well.