### PR TITLE
fix: add Node.js 22 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Roon Labs, LLC",
   "license": "Apache-2.0",
   "dependencies": {
-    "ip": "^1.1.3",
+    "ip": "^2.0.1",
     "node-uuid": "^1.4.7",
     "ws": ">=3.3.1"
   }

--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// polyfill websockets in Node
-if (typeof(WebSocket) == "undefined") global.WebSocket = require('ws');
+// force polyfill websockets in Node to support Node 22+
+if (typeof(window) == "undefined" || typeof(WebSocket) == "undefined") global.WebSocket = require('ws');
 
 function Transport(ip, port, logger) {
     this.host = ip;


### PR DESCRIPTION
Support Node.js 22+  by forcing the use of `ws` in the polyfill declaration.

fixes #37 