### PR TITLE
feat: add disconnect_all & stop_discovery to RoonApi

### DIFF
--- a/sood.js
+++ b/sood.js
@@ -19,6 +19,7 @@ function Sood(logger) {
     this._unicast = {};
     this._iface_seq = 0;
     this.logger = logger;
+    this.interface_timer = 0;
 //    this.on("message", (msg) => { this.logger.log(JSON.stringify(msg)); });
 };
 
@@ -162,9 +163,8 @@ Sood.prototype.start = function(cb) {
     this.initsocket(cb);
 };
 Sood.prototype.stop = function() {
-    if (this.interface_timer) clearInterval(interface_timer);
-    delete(this.interface_timer);
-    for (ip in this._multicast) {
+    if (this.interface_timer) clearInterval(this.interface_timer);
+    for (const ip in this._multicast) {
 	try { this._multicast[ip].recv_sock.close(); } catch (e) { }
 	try { this._multicast[ip].send_sock.close(); } catch (e) { }
     }

--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -42,7 +42,10 @@ function Transport(ip, port, logger) {
     }
 
     this.ws.onmessage = (event) => {
-        var msg = this.moo.parse(event.data);
+        if (!this.moo) {
+            return;
+        }
+        const msg = this.moo.parse(event.data);
         if (!msg) {
             this.close();
             return;
@@ -57,6 +60,7 @@ Transport.prototype.send = function(buf) {
 
 Transport.prototype.close = function() {
     if (this.ws) {
+        clearInterval(this.interval);
         this.ws.close();
         this.ws = undefined;
     }


### PR DESCRIPTION
New API methods to disconnect and remain disconnected from Roon core. This can be useful for not-always connected clients, especially for battery powered devices supporting standby.

This allows to disconnect from Roon before entering standby, and immediately reconnect after waking up (if the client has access to standby events), significantly speeding up the reconnection time.

The old logic can take up to a minute to reconnect, whereas manually disconnecting & reconnecting usually takes less than 1-2 seconds.

Other fixes:
- `Sood.prototype.stop` function was crashing at runtime.
- `Transport.prototype.close` needs to stop the WS ping timer, otherwise it tries to use a no longer existing ws instance and crashes.
