### PR TITLE
fix: check if WebSocket instance is available before use

### DIFF
--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -18,6 +18,10 @@ function Transport(ip, port, logger) {
     this.ws.onopen = () => {
         this.is_alive = true;
         this.interval = setInterval(() => {
+            if (!this.ws) {
+                this.close();
+                return;
+            }
             if (this.is_alive === false) {
                 logger.log(`Roon API Connection to ${this.host}:${this.port} closed due to missed heartbeat`);
                 return this.ws.terminate();
@@ -52,6 +56,10 @@ function Transport(ip, port, logger) {
 }
 
 Transport.prototype.send = function(buf) {
+    if (!this.ws) {
+        this.close();
+        return;
+    }
     this.ws.send(buf, { binary: true, mask: true});
 };
 


### PR DESCRIPTION
This fixes sporadic runtime crashes, where the client tries to send a message with `Transport.send`, but the ws instance is no longer available.

Example:
```
/projects/integration-roon/node_modules/node-roon-api/transport-websocket.js:38
    this.ws.send(buf, { binary: true, mask: true});
            ^

TypeError: Cannot read properties of undefined (reading 'send')
    at Transport.send (/projects/integration-roon/node_modules/node-roon-api/transport-websocket.js:38:13)
    at Moo.send_request (/projects/integration-roon/node_modules/node-roon-api/moo.js:75:24)
    at RoonApiTransport.get_zones (/projects/integration-roon/node_modules/node-roon-api-transport/lib.js:339:19)
```
